### PR TITLE
feat: expose judge tools, batch_run, verified-alive scan, rate limiting

### DIFF
--- a/src/model_radar/judge.py
+++ b/src/model_radar/judge.py
@@ -694,6 +694,7 @@ async def batch_judge_items(
     max_tokens: int = 256,
     temperature: float = 0.0,
     state: ScanState | None = None,
+    results_file: str | None = None,
 ) -> dict:
     """Run judge evaluations at scale on a list of items.
 
@@ -713,9 +714,26 @@ async def batch_judge_items(
         temperature: Sampling temperature
         state: Shared scan state
 
+    Args:
+        items: List of dicts with "prompt" key (and optional "metadata")
+        rubric: List of dimension names
+        scale: Rating scale
+        judge_count: Judges per item
+        min_tier: Minimum quality tier for judge selection
+        free_only: Only use free models
+        output_format: "csv" or "json"
+        concurrency: Max items evaluated in parallel
+        max_tokens: Max response tokens per judge
+        temperature: Sampling temperature
+        state: Shared scan state
+        results_file: Path to JSONL file for incremental writes; if the file
+            exists, already-scored indices are skipped (resume support)
+
     Returns:
         Dict with all results, summary statistics, and error count.
     """
+    import json as _json
+
     if not items:
         return {"error": "items list is empty"}
     if not rubric:
@@ -727,6 +745,21 @@ async def batch_judge_items(
     )
     if not judges:
         return {"error": "No judge models available. Check API keys with list_providers()."}
+
+    # Resume support: load already-scored indices from results_file
+    completed_indices: dict[int, dict] = {}
+    if results_file:
+        try:
+            with open(results_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        entry = _json.loads(line)
+                        idx = entry.get("index", -1)
+                        if idx >= 0 and "scores" in entry:
+                            completed_indices[idx] = entry
+        except FileNotFoundError:
+            pass
 
     cfg = load_config()
     system_prompt = _build_judge_system_prompt(rubric, scale, output_format)
@@ -791,20 +824,43 @@ async def batch_judge_items(
                 "metadata": item.get("metadata"),
             }
 
-    # Run all items with bounded concurrency
-    tasks = [_evaluate_one(i, item) for i, item in enumerate(items)]
-    results = await asyncio.gather(*tasks)
+    # Open results file for incremental writes
+    results_fh = None
+    if results_file:
+        results_fh = open(results_file, "a")
+
+    try:
+        # Build task list, skipping already-completed items
+        pending_tasks = []
+        results_list: list[dict] = [{}] * len(items)
+        for i, item in enumerate(items):
+            if i in completed_indices:
+                results_list[i] = completed_indices[i]
+            else:
+                pending_tasks.append(_evaluate_one(i, item))
+
+        completed = await asyncio.gather(*pending_tasks)
+
+        for r in completed:
+            idx = r["index"]
+            results_list[idx] = r
+            if results_fh:
+                results_fh.write(_json.dumps(r) + "\n")
+                results_fh.flush()
+    finally:
+        if results_fh:
+            results_fh.close()
 
     # Sort by original index
-    results.sort(key=lambda r: r["index"])
+    results_list.sort(key=lambda r: r.get("index", 0))
 
     # Compute summary statistics
-    total_errors = sum(1 for r in results if "error" in r and "scores" not in r)
-    total_judge_failures = sum(r.get("judges_failed", 0) for r in results)
+    total_errors = sum(1 for r in results_list if "error" in r and "scores" not in r)
+    total_judge_failures = sum(r.get("judges_failed", 0) for r in results_list)
 
     # Aggregate scores across all items per dimension
     dim_means: dict[str, list[float]] = defaultdict(list)
-    for r in results:
+    for r in results_list:
         for dim in rubric:
             if dim in r.get("scores", {}):
                 dim_means[dim].append(r["scores"][dim])
@@ -824,12 +880,19 @@ async def batch_judge_items(
         f"{j.label} ({PROVIDERS[j.provider].name})" for j in judges
     ]
 
-    return {
+    result = {
         "items_total": len(items),
         "items_scored": len(items) - total_errors,
         "items_errored": total_errors,
         "total_judge_failures": total_judge_failures,
         "judges_used": judges_used,
         "summary": summary,
-        "results": results,
+        "results": results_list,
     }
+    skipped = len(completed_indices)
+    if skipped:
+        result["items_resumed"] = skipped
+    if results_file:
+        result["results_file"] = results_file
+
+    return result

--- a/src/model_radar/judge.py
+++ b/src/model_radar/judge.py
@@ -1,0 +1,835 @@
+"""
+LLM-as-judge evaluation — rate items, compare pairs, and run batch evaluations.
+
+Builds on the existing ask/run infrastructure but adds:
+- Structured output parsing (CSV scores)
+- Provider diversity (no two judges from same provider)
+- Automatic failover on judge failure
+- Inter-rater agreement metrics
+- Blind A/B comparison with position-bias detection
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import re
+import statistics
+from collections import defaultdict
+from itertools import combinations
+
+from .config import load_config
+from .providers import PROVIDERS, Model
+from .quality import get_model_quality
+from .runner import _call_model
+from .scanner import ScanState, scan_models
+
+
+def _build_judge_system_prompt(
+    rubric: list[str],
+    scale: str,
+    output_format: str,
+) -> str:
+    """Build a system prompt that instructs the judge to output structured scores."""
+    n = len(rubric)
+    rubric_list = ", ".join(rubric)
+
+    if output_format == "csv":
+        format_instruction = (
+            f"Output ONLY {n} numbers separated by commas, one for each dimension "
+            f"in this order: {rubric_list}. "
+            f"Use the scale {scale}. No words, no explanation, just the numbers."
+        )
+        example = ",".join(["4"] * n) if n > 0 else "4"
+        format_instruction += f"\n\nExample output: {example}"
+    else:
+        format_instruction = (
+            f"Rate each dimension on the scale {scale}. "
+            f"Dimensions: {rubric_list}. "
+            f"Output ONLY a JSON object with dimension names as keys and numeric scores as values."
+        )
+
+    return (
+        "You are an expert evaluator. Your job is to rate content on specific dimensions.\n\n"
+        f"{format_instruction}"
+    )
+
+
+def _parse_csv_scores(content: str, rubric: list[str], scale: str) -> dict | None:
+    """Parse a CSV response like '4,5,3' into {dimension: score}."""
+    content = content.strip()
+    # Remove any surrounding quotes or backticks
+    content = content.strip("`'\"")
+
+    # Try to extract numbers from the response
+    numbers = re.findall(r"(\d+(?:\.\d+)?)", content)
+    if len(numbers) < len(rubric):
+        return None
+
+    # Parse scale bounds
+    parts = scale.split("-")
+    if len(parts) != 2:
+        return None
+    try:
+        lo, hi = float(parts[0]), float(parts[1])
+    except ValueError:
+        return None
+
+    scores = {}
+    for i, dim in enumerate(rubric):
+        val = float(numbers[i])
+        if val < lo or val > hi:
+            return None
+        scores[dim] = val
+
+    return scores
+
+
+def _parse_json_scores(content: str, rubric: list[str], scale: str) -> dict | None:
+    """Parse a JSON response into {dimension: score}."""
+    import json
+
+    content = content.strip()
+    # Try to extract JSON from the response
+    match = re.search(r"\{[^}]+\}", content)
+    if not match:
+        return None
+
+    try:
+        data = json.loads(match.group())
+    except json.JSONDecodeError:
+        return None
+
+    parts = scale.split("-")
+    if len(parts) != 2:
+        return None
+    try:
+        lo, hi = float(parts[0]), float(parts[1])
+    except ValueError:
+        return None
+
+    scores = {}
+    for dim in rubric:
+        # Try exact match, then case-insensitive
+        val = data.get(dim)
+        if val is None:
+            for k, v in data.items():
+                if k.lower() == dim.lower():
+                    val = v
+                    break
+        if val is None:
+            return None
+        try:
+            val = float(val)
+        except (ValueError, TypeError):
+            return None
+        if val < lo or val > hi:
+            return None
+        scores[dim] = val
+
+    return scores
+
+
+def _parse_scores(
+    content: str, rubric: list[str], scale: str, output_format: str
+) -> dict | None:
+    """Parse judge response into dimension scores. Returns None if malformed."""
+    if output_format == "csv":
+        return _parse_csv_scores(content, rubric, scale)
+    return _parse_json_scores(content, rubric, scale)
+
+
+async def _select_diverse_judges(
+    count: int,
+    min_tier: str = "A",
+    free_only: bool = False,
+    state: ScanState | None = None,
+) -> list[Model]:
+    """Select judge models spread across different providers.
+
+    Returns up to `count` models, each from a different provider when possible.
+    Falls back to same-provider models if not enough providers are available.
+    """
+    # Scan a wider pool to allow provider diversity
+    results = await scan_models(
+        min_tier=min_tier,
+        configured_only=True,
+        free_only=free_only,
+        limit=count * 4,
+        state=state,
+    )
+    up_models = [r.model for r in results if r.status == "up"]
+
+    if not up_models:
+        return []
+
+    # Pick one model per provider first (fastest from each)
+    seen_providers: set[str] = set()
+    diverse: list[Model] = []
+    remaining: list[Model] = []
+
+    for m in up_models:
+        if m.provider not in seen_providers and len(diverse) < count:
+            diverse.append(m)
+            seen_providers.add(m.provider)
+        else:
+            remaining.append(m)
+
+    # Fill remaining slots from leftover models if needed
+    while len(diverse) < count and remaining:
+        diverse.append(remaining.pop(0))
+
+    return diverse[:count]
+
+
+async def _call_judge_with_retry(
+    model: Model,
+    messages: list[dict],
+    cfg: dict,
+    rubric: list[str],
+    scale: str,
+    output_format: str,
+    max_retries: int = 2,
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+) -> dict:
+    """Call a judge model with retry on malformed output."""
+    for attempt in range(max_retries + 1):
+        result = await _call_model(
+            model=model,
+            messages=messages,
+            cfg=cfg,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+        if "error" in result:
+            return {"error": result["error"], "model": model, "raw": result}
+
+        content = result.get("content", "")
+        if not content:
+            if attempt < max_retries:
+                continue
+            return {"error": "empty_response", "model": model, "raw": result}
+
+        scores = _parse_scores(content, rubric, scale, output_format)
+        if scores is not None:
+            return {
+                "scores": scores,
+                "model": model,
+                "raw_content": content,
+                "latency_ms": result.get("latency_ms"),
+            }
+
+        # Malformed output — retry
+        if attempt < max_retries:
+            continue
+
+    return {"error": "malformed_output", "model": model, "raw_content": content}
+
+
+def _compute_agreement(per_judge: list[dict], rubric: list[str]) -> dict:
+    """Compute inter-rater agreement metrics across judges."""
+    if len(per_judge) < 2:
+        return {"note": "need at least 2 judges for agreement metrics"}
+
+    # Collect scores per dimension
+    dim_scores: dict[str, list[float]] = defaultdict(list)
+    for entry in per_judge:
+        scores = entry.get("scores", {})
+        for dim in rubric:
+            if dim in scores:
+                dim_scores[dim].append(scores[dim])
+
+    # Mean pairwise difference per dimension
+    pairwise_diffs: dict[str, float] = {}
+    for dim, vals in dim_scores.items():
+        if len(vals) < 2:
+            continue
+        diffs = [abs(a - b) for a, b in combinations(vals, 2)]
+        pairwise_diffs[dim] = round(statistics.mean(diffs), 3)
+
+    # Overall mean pairwise difference
+    all_diffs = list(pairwise_diffs.values())
+    overall = round(statistics.mean(all_diffs), 3) if all_diffs else None
+
+    result = {"mean_pairwise_diff": overall, "per_dimension": pairwise_diffs}
+
+    # Standard deviation per dimension (if 3+ judges)
+    if len(per_judge) >= 3:
+        stdevs = {}
+        for dim, vals in dim_scores.items():
+            if len(vals) >= 3:
+                stdevs[dim] = round(statistics.stdev(vals), 3)
+        if stdevs:
+            result["stdev"] = stdevs
+
+    return result
+
+
+async def judge_item(
+    prompt: str,
+    rubric: list[str],
+    scale: str = "1-5",
+    count: int = 3,
+    min_tier: str = "A",
+    free_only: bool = False,
+    output_format: str = "csv",
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+    state: ScanState | None = None,
+) -> dict:
+    """Rate a single item using N judge models.
+
+    Auto-selects judges from the live model pool, spread across providers.
+    Parses structured output, computes aggregate scores and inter-rater agreement.
+
+    Args:
+        prompt: The evaluation prompt (what to rate)
+        rubric: List of dimension names (e.g. ["accuracy", "naturalness"])
+        scale: Rating scale (e.g. "1-5", "1-10")
+        count: Number of judge models to use
+        min_tier: Minimum quality tier for judge selection
+        free_only: Only use free models as judges
+        output_format: "csv" or "json" — how judges should format scores
+        max_tokens: Max response tokens per judge
+        temperature: Sampling temperature
+        state: Shared scan state
+
+    Returns:
+        Dict with aggregate scores, per-judge details, and agreement metrics.
+    """
+    if not rubric:
+        return {"error": "rubric must contain at least one dimension"}
+
+    cfg = load_config()
+
+    # Select diverse judges
+    judges = await _select_diverse_judges(
+        count=count, min_tier=min_tier, free_only=free_only, state=state
+    )
+    if not judges:
+        return {"error": "No judge models available. Check API keys with list_providers()."}
+
+    # Build messages
+    system_prompt = _build_judge_system_prompt(rubric, scale, output_format)
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": prompt},
+    ]
+
+    # Call all judges in parallel
+    tasks = [
+        _call_judge_with_retry(
+            model=j,
+            messages=messages,
+            cfg=cfg,
+            rubric=rubric,
+            scale=scale,
+            output_format=output_format,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        for j in judges
+    ]
+    results = await asyncio.gather(*tasks)
+
+    # Separate successes and failures
+    per_judge = []
+    errors = 0
+    for r in results:
+        model = r["model"]
+        prov = PROVIDERS.get(model.provider)
+        entry = {
+            "model_id": model.model_id,
+            "model_label": model.label,
+            "provider": prov.name if prov else model.provider,
+        }
+
+        if "scores" in r:
+            entry["scores"] = r["scores"]
+            entry["latency_ms"] = r.get("latency_ms")
+            per_judge.append(entry)
+        else:
+            entry["error"] = r.get("error", "unknown")
+            entry["raw_content"] = r.get("raw_content")
+            per_judge.append(entry)
+            errors += 1
+
+    # Compute aggregate scores
+    successful = [e for e in per_judge if "scores" in e]
+    aggregate: dict[str, float] = {}
+    if successful:
+        for dim in rubric:
+            vals = [e["scores"][dim] for e in successful if dim in e["scores"]]
+            if vals:
+                aggregate[dim] = round(statistics.mean(vals), 2)
+
+    # Compute agreement
+    agreement = _compute_agreement(successful, rubric)
+
+    judges_used = [
+        f"{e['model_label']} ({e['provider']})" for e in per_judge if "scores" in e
+    ]
+
+    return {
+        "scores": aggregate,
+        "judges_used": judges_used,
+        "judge_count": len(judges),
+        "judges_succeeded": len(successful),
+        "per_judge": per_judge,
+        "inter_rater_agreement": agreement,
+        "errors": errors,
+    }
+
+
+def _build_compare_prompt(
+    item_a: str,
+    item_b: str,
+    context: str | None,
+    dimensions: list[str],
+    scale: str,
+    labels: tuple[str, str],
+) -> str:
+    """Build comparison prompt with given A/B labels."""
+    parts = []
+    if context:
+        parts.append(f"Context: {context}")
+    parts.append(f"Item {labels[0]}:\n{item_a}")
+    parts.append(f"Item {labels[1]}:\n{item_b}")
+
+    dim_list = ", ".join(dimensions)
+    parts.append(
+        f"\nRate each item on these dimensions: {dim_list}. Scale: {scale}.\n"
+        f"Output ONLY two lines of comma-separated scores, one per item:\n"
+        f"{labels[0]}: <scores>\n"
+        f"{labels[1]}: <scores>"
+    )
+    return "\n\n".join(parts)
+
+
+def _parse_compare_scores(
+    content: str,
+    dimensions: list[str],
+    scale: str,
+    labels: tuple[str, str],
+) -> tuple[dict | None, dict | None]:
+    """Parse comparison response into two sets of scores."""
+    parts = scale.split("-")
+    if len(parts) != 2:
+        return None, None
+    try:
+        lo, hi = float(parts[0]), float(parts[1])
+    except ValueError:
+        return None, None
+
+    lines = [line.strip() for line in content.strip().splitlines() if line.strip()]
+
+    scores_list: list[dict] = []
+    for line in lines:
+        # Remove label prefix if present
+        for label in labels:
+            if line.upper().startswith(label + ":"):
+                line = line[len(label) + 1:].strip()
+                break
+
+        numbers = re.findall(r"(\d+(?:\.\d+)?)", line)
+        if len(numbers) >= len(dimensions):
+            scores = {}
+            valid = True
+            for i, dim in enumerate(dimensions):
+                val = float(numbers[i])
+                if val < lo or val > hi:
+                    valid = False
+                    break
+                scores[dim] = val
+            if valid:
+                scores_list.append(scores)
+
+        if len(scores_list) == 2:
+            break
+
+    if len(scores_list) == 2:
+        return scores_list[0], scores_list[1]
+    return None, None
+
+
+async def compare_items(
+    item_a: str,
+    item_b: str,
+    context: str | None = None,
+    dimensions: list[str] | None = None,
+    scale: str = "1-5",
+    judge_count: int = 3,
+    blind: bool = True,
+    min_tier: str = "A",
+    free_only: bool = False,
+    max_tokens: int = 512,
+    temperature: float = 0.0,
+    state: ScanState | None = None,
+) -> dict:
+    """Blind A/B comparison judged by N models.
+
+    When blind=True, randomizes which item is shown as A vs B to each judge
+    independently, then de-randomizes scores to prevent position bias.
+
+    Args:
+        item_a: First item to compare
+        item_b: Second item to compare
+        context: Optional context for the comparison
+        dimensions: Scoring dimensions (default: ["quality"])
+        scale: Rating scale (e.g. "1-5")
+        judge_count: Number of judge models
+        blind: Randomize A/B order per judge to prevent position bias
+        min_tier: Minimum quality tier for judge selection
+        free_only: Only use free models as judges
+        max_tokens: Max response tokens per judge
+        temperature: Sampling temperature
+        state: Shared scan state
+
+    Returns:
+        Dict with winner, per-item scores, win counts, and position bias detection.
+    """
+    if dimensions is None:
+        dimensions = ["quality"]
+
+    cfg = load_config()
+
+    judges = await _select_diverse_judges(
+        count=judge_count, min_tier=min_tier, free_only=free_only, state=state
+    )
+    if not judges:
+        return {"error": "No judge models available. Check API keys with list_providers()."}
+
+    # For each judge, potentially swap A/B order
+    judge_orders: list[tuple[Model, bool]] = []  # (model, swapped)
+    for j in judges:
+        swapped = blind and random.random() < 0.5
+        judge_orders.append((j, swapped))
+
+    async def _call_compare_judge(model: Model, swapped: bool) -> dict:
+        if swapped:
+            actual_a, actual_b = item_b, item_a
+        else:
+            actual_a, actual_b = item_a, item_b
+
+        prompt = _build_compare_prompt(
+            actual_a, actual_b, context, dimensions, scale, ("A", "B")
+        )
+        messages = [
+            {"role": "system", "content": (
+                "You are an expert evaluator comparing two items. "
+                "Rate each item on the given dimensions. "
+                "Output ONLY scores, no explanation."
+            )},
+            {"role": "user", "content": prompt},
+        ]
+
+        result = await _call_model(
+            model=model,
+            messages=messages,
+            cfg=cfg,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+        if "error" in result:
+            return {"error": result["error"], "model": model, "swapped": swapped}
+
+        content = result.get("content", "")
+        scores_first, scores_second = _parse_compare_scores(
+            content, dimensions, scale, ("A", "B")
+        )
+
+        if scores_first is None or scores_second is None:
+            return {
+                "error": "malformed_output",
+                "model": model,
+                "swapped": swapped,
+                "raw_content": content,
+            }
+
+        # De-randomize: if swapped, what was labeled "A" is actually item_b
+        if swapped:
+            return {
+                "scores_a": scores_second,
+                "scores_b": scores_first,
+                "model": model,
+                "swapped": swapped,
+                "latency_ms": result.get("latency_ms"),
+            }
+        return {
+            "scores_a": scores_first,
+            "scores_b": scores_second,
+            "model": model,
+            "swapped": swapped,
+            "latency_ms": result.get("latency_ms"),
+        }
+
+    # Run all judges in parallel
+    tasks = [_call_compare_judge(m, s) for m, s in judge_orders]
+    results = await asyncio.gather(*tasks)
+
+    # Aggregate results
+    per_judge = []
+    all_scores_a: dict[str, list[float]] = defaultdict(list)
+    all_scores_b: dict[str, list[float]] = defaultdict(list)
+    wins = {"A": 0, "B": 0, "tie": 0}
+    errors = 0
+
+    for r in results:
+        model = r["model"]
+        prov = PROVIDERS.get(model.provider)
+        entry = {
+            "model_id": model.model_id,
+            "model_label": model.label,
+            "provider": prov.name if prov else model.provider,
+            "order_swapped": r.get("swapped", False),
+        }
+
+        if "scores_a" in r:
+            entry["scores_a"] = r["scores_a"]
+            entry["scores_b"] = r["scores_b"]
+            entry["latency_ms"] = r.get("latency_ms")
+
+            # Determine winner for this judge
+            mean_a = statistics.mean(r["scores_a"].values())
+            mean_b = statistics.mean(r["scores_b"].values())
+            if mean_a > mean_b:
+                wins["A"] += 1
+            elif mean_b > mean_a:
+                wins["B"] += 1
+            else:
+                wins["tie"] += 1
+
+            for dim in dimensions:
+                if dim in r["scores_a"]:
+                    all_scores_a[dim].append(r["scores_a"][dim])
+                if dim in r["scores_b"]:
+                    all_scores_b[dim].append(r["scores_b"][dim])
+        else:
+            entry["error"] = r.get("error", "unknown")
+            errors += 1
+
+        per_judge.append(entry)
+
+    # Compute average scores
+    avg_a = {dim: round(statistics.mean(vals), 2) for dim, vals in all_scores_a.items()}
+    avg_b = {dim: round(statistics.mean(vals), 2) for dim, vals in all_scores_b.items()}
+
+    # Determine overall winner
+    total_a = sum(avg_a.values()) if avg_a else 0
+    total_b = sum(avg_b.values()) if avg_b else 0
+    if total_a > total_b:
+        winner = "A"
+    elif total_b > total_a:
+        winner = "B"
+    else:
+        winner = "tie"
+
+    # Position bias detection
+    position_bias = None
+    if blind:
+        successful = [e for e in per_judge if "scores_a" in e]
+        if len(successful) >= 3:
+            # Check if judges who saw items in original order consistently differ
+            # from judges who saw items swapped
+            orig_order_a_wins = 0
+            swap_order_a_wins = 0
+            orig_count = 0
+            swap_count = 0
+            for e in successful:
+                mean_a = statistics.mean(e["scores_a"].values())
+                mean_b = statistics.mean(e["scores_b"].values())
+                if e["order_swapped"]:
+                    swap_count += 1
+                    if mean_a > mean_b:
+                        swap_order_a_wins += 1
+                else:
+                    orig_count += 1
+                    if mean_a > mean_b:
+                        orig_order_a_wins += 1
+
+            if orig_count > 0 and swap_count > 0:
+                orig_a_rate = orig_order_a_wins / orig_count
+                swap_a_rate = swap_order_a_wins / swap_count
+                if abs(orig_a_rate - swap_a_rate) > 0.5:
+                    position_bias = {
+                        "detected": True,
+                        "note": "Judges may be favoring whichever item appears first",
+                        "orig_order_a_win_rate": round(orig_a_rate, 2),
+                        "swapped_order_a_win_rate": round(swap_a_rate, 2),
+                    }
+
+    judges_used = [
+        f"{e['model_label']} ({e['provider']})" for e in per_judge if "scores_a" in e
+    ]
+
+    result = {
+        "winner": winner,
+        "scores_a": avg_a,
+        "scores_b": avg_b,
+        "wins": wins,
+        "judges_used": judges_used,
+        "judge_count": len(judges),
+        "judges_succeeded": len(judges_used),
+        "per_judge": per_judge,
+        "errors": errors,
+    }
+    if position_bias:
+        result["position_bias"] = position_bias
+
+    return result
+
+
+async def batch_judge_items(
+    items: list[dict],
+    rubric: list[str],
+    scale: str = "1-5",
+    judge_count: int = 3,
+    min_tier: str = "A",
+    free_only: bool = False,
+    output_format: str = "csv",
+    concurrency: int = 5,
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+    state: ScanState | None = None,
+) -> dict:
+    """Run judge evaluations at scale on a list of items.
+
+    Processes items with bounded concurrency. Returns results incrementally
+    so partial progress is available even if interrupted.
+
+    Args:
+        items: List of dicts with "prompt" key (and optional "metadata")
+        rubric: List of dimension names
+        scale: Rating scale
+        judge_count: Judges per item
+        min_tier: Minimum quality tier for judge selection
+        free_only: Only use free models
+        output_format: "csv" or "json"
+        concurrency: Max items evaluated in parallel
+        max_tokens: Max response tokens per judge
+        temperature: Sampling temperature
+        state: Shared scan state
+
+    Returns:
+        Dict with all results, summary statistics, and error count.
+    """
+    if not items:
+        return {"error": "items list is empty"}
+    if not rubric:
+        return {"error": "rubric must contain at least one dimension"}
+
+    # Pre-select judge pool once (reused across items for consistency)
+    judges = await _select_diverse_judges(
+        count=judge_count, min_tier=min_tier, free_only=free_only, state=state
+    )
+    if not judges:
+        return {"error": "No judge models available. Check API keys with list_providers()."}
+
+    cfg = load_config()
+    system_prompt = _build_judge_system_prompt(rubric, scale, output_format)
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _evaluate_one(idx: int, item: dict) -> dict:
+        async with semaphore:
+            prompt = item.get("prompt", "")
+            if not prompt:
+                return {"index": idx, "error": "missing prompt", "metadata": item.get("metadata")}
+
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ]
+
+            # Call all judges for this item in parallel
+            tasks = [
+                _call_judge_with_retry(
+                    model=j,
+                    messages=messages,
+                    cfg=cfg,
+                    rubric=rubric,
+                    scale=scale,
+                    output_format=output_format,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
+                for j in judges
+            ]
+            results = await asyncio.gather(*tasks)
+
+            per_judge = []
+            for r in results:
+                model = r["model"]
+                prov = PROVIDERS.get(model.provider)
+                entry = {
+                    "model_id": model.model_id,
+                    "model_label": model.label,
+                    "provider": prov.name if prov else model.provider,
+                }
+                if "scores" in r:
+                    entry["scores"] = r["scores"]
+                else:
+                    entry["error"] = r.get("error", "unknown")
+                per_judge.append(entry)
+
+            successful = [e for e in per_judge if "scores" in e]
+            aggregate: dict[str, float] = {}
+            if successful:
+                for dim in rubric:
+                    vals = [e["scores"][dim] for e in successful if dim in e["scores"]]
+                    if vals:
+                        aggregate[dim] = round(statistics.mean(vals), 2)
+
+            return {
+                "index": idx,
+                "scores": aggregate,
+                "judges_succeeded": len(successful),
+                "judges_failed": len(per_judge) - len(successful),
+                "per_judge": per_judge,
+                "metadata": item.get("metadata"),
+            }
+
+    # Run all items with bounded concurrency
+    tasks = [_evaluate_one(i, item) for i, item in enumerate(items)]
+    results = await asyncio.gather(*tasks)
+
+    # Sort by original index
+    results.sort(key=lambda r: r["index"])
+
+    # Compute summary statistics
+    total_errors = sum(1 for r in results if "error" in r and "scores" not in r)
+    total_judge_failures = sum(r.get("judges_failed", 0) for r in results)
+
+    # Aggregate scores across all items per dimension
+    dim_means: dict[str, list[float]] = defaultdict(list)
+    for r in results:
+        for dim in rubric:
+            if dim in r.get("scores", {}):
+                dim_means[dim].append(r["scores"][dim])
+
+    summary = {
+        dim: {
+            "mean": round(statistics.mean(vals), 2),
+            "stdev": round(statistics.stdev(vals), 2) if len(vals) >= 2 else 0.0,
+            "min": round(min(vals), 2),
+            "max": round(max(vals), 2),
+            "n": len(vals),
+        }
+        for dim, vals in dim_means.items()
+    }
+
+    judges_used = [
+        f"{j.label} ({PROVIDERS[j.provider].name})" for j in judges
+    ]
+
+    return {
+        "items_total": len(items),
+        "items_scored": len(items) - total_errors,
+        "items_errored": total_errors,
+        "total_judge_failures": total_judge_failures,
+        "judges_used": judges_used,
+        "summary": summary,
+        "results": results,
+    }

--- a/src/model_radar/runner.py
+++ b/src/model_radar/runner.py
@@ -7,6 +7,8 @@ a chat/completions request, returning the full response.
 
 from __future__ import annotations
 
+import asyncio
+import json as _json
 import os
 import time
 
@@ -14,7 +16,10 @@ import httpx
 
 from .config import get_api_key, load_config
 from .providers import PROVIDERS, Model
-from .scanner import ScanState, scan_models
+from .scanner import ProviderThrottle, ScanState, scan_models
+
+# Module-level throttle instance shared across all calls
+_throttle = ProviderThrottle()
 
 
 async def _call_model(
@@ -23,11 +28,18 @@ async def _call_model(
     cfg: dict,
     max_tokens: int = 4096,
     temperature: float = 0.0,
+    throttle: ProviderThrottle | None = None,
 ) -> dict:
     """Send a chat/completions request to a model and return the response."""
     api_key = get_api_key(cfg, model.provider)
     if not api_key:
         return {"error": f"No API key for provider {model.provider}"}
+
+    # Adaptive rate limiting
+    _thr = throttle or _throttle
+    delay = _thr.should_throttle(model.provider)
+    if delay > 0:
+        await asyncio.sleep(delay)
 
     prov = PROVIDERS[model.provider]
     url = prov.url
@@ -69,6 +81,8 @@ async def _call_model(
         elapsed_ms = (time.monotonic() - start) * 1000
 
     if resp.status_code not in (200, 201):
+        if resp.status_code == 429:
+            _thr.record_429(model.provider)
         return {
             "error": f"HTTP {resp.status_code}",
             "detail": resp.text[:500],
@@ -76,6 +90,7 @@ async def _call_model(
             "provider": prov.name,
         }
 
+    _thr.record_success(model.provider)
     data = resp.json()
     usage = data.get("usage", {})
 
@@ -230,3 +245,186 @@ async def run_on_fastest(
                  + ", ".join(r["model_label"] for r in retries),
         "retries": retries,
     }
+
+
+async def batch_run(
+    prompts: list[dict],
+    system_prompt: str | None = None,
+    model_id: str | None = None,
+    provider: str | None = None,
+    min_tier: str = "A",
+    free_only: bool = False,
+    max_tokens: int = 4096,
+    temperature: float = 0.0,
+    concurrency: int = 5,
+    retry_on_fail: bool = True,
+    results_file: str | None = None,
+    state: ScanState | None = None,
+) -> dict:
+    """Run multiple prompts with bounded concurrency and optional auto-retry.
+
+    Each prompt dict should have a "prompt" key and optional "system_prompt"
+    and "metadata" keys.  When model_id is not specified, scans for the
+    fastest model first and uses it for all items; failed items are retried
+    on alternate models when retry_on_fail is True.
+
+    Args:
+        prompts: List of {"prompt": "...", "system_prompt": "...", "metadata": {...}}
+        system_prompt: Default system prompt (per-item system_prompt overrides)
+        model_id: Specific model to use for all items
+        provider: Limit to a specific provider
+        min_tier: Minimum quality tier when auto-selecting
+        free_only: Only use free models
+        max_tokens: Max response tokens per item
+        temperature: Sampling temperature
+        concurrency: Max parallel requests
+        retry_on_fail: Auto-retry failed items on alternate models
+        results_file: Optional path to a JSONL file for incremental writes
+        state: Shared scan state
+
+    Returns:
+        Dict with results array, summary counts, and model info.
+    """
+    if not prompts:
+        return {"error": "prompts list is empty"}
+
+    cfg = load_config()
+
+    # Resolve target model(s)
+    if model_id:
+        target = _find_model(model_id, provider)
+        if not target:
+            return {"error": f"Model '{model_id}' not found in registry"}
+        primary_model = target
+        fallback_models: list[Model] = []
+    else:
+        scan_results = await scan_models(
+            min_tier=min_tier, provider=provider,
+            configured_only=True, free_only=free_only,
+            limit=concurrency + 5, state=state,
+        )
+        up_models = [r.model for r in scan_results if r.status == "up"]
+        if not up_models:
+            return {"error": "No models available. Check API keys with list_providers()."}
+        primary_model = up_models[0]
+        fallback_models = up_models[1:4] if retry_on_fail else []
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    # Resume support: load already-completed indices from results_file
+    completed_indices: set[int] = set()
+    if results_file:
+        try:
+            with open(results_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        entry = _json.loads(line)
+                        if "error" not in entry:
+                            completed_indices.add(entry.get("index", -1))
+        except FileNotFoundError:
+            pass
+
+    results: list[dict] = [{}] * len(prompts)
+
+    async def _run_one(idx: int, item: dict) -> dict:
+        async with semaphore:
+            prompt_text = item.get("prompt", "")
+            if not prompt_text:
+                return {"index": idx, "error": "missing prompt", "metadata": item.get("metadata")}
+
+            # Build messages
+            sys = item.get("system_prompt") or system_prompt
+            messages = []
+            if sys:
+                messages.append({"role": "system", "content": sys})
+            messages.append({"role": "user", "content": prompt_text})
+
+            # Try primary model
+            result = await _call_model(
+                model=primary_model, messages=messages, cfg=cfg,
+                max_tokens=max_tokens, temperature=temperature,
+            )
+            if "error" not in result:
+                return {
+                    "index": idx,
+                    "content": result.get("content", ""),
+                    "model_id": result.get("model_id"),
+                    "model_label": result.get("model_label"),
+                    "provider": result.get("provider"),
+                    "latency_ms": result.get("latency_ms"),
+                    "usage": result.get("usage"),
+                    "metadata": item.get("metadata"),
+                }
+
+            # Retry on fallbacks
+            if retry_on_fail:
+                for fb in fallback_models:
+                    fb_result = await _call_model(
+                        model=fb, messages=messages, cfg=cfg,
+                        max_tokens=max_tokens, temperature=temperature,
+                    )
+                    if "error" not in fb_result:
+                        return {
+                            "index": idx,
+                            "content": fb_result.get("content", ""),
+                            "model_id": fb_result.get("model_id"),
+                            "model_label": fb_result.get("model_label"),
+                            "provider": fb_result.get("provider"),
+                            "latency_ms": fb_result.get("latency_ms"),
+                            "usage": fb_result.get("usage"),
+                            "metadata": item.get("metadata"),
+                            "retried": True,
+                        }
+
+            return {
+                "index": idx,
+                "error": result.get("error", "unknown"),
+                "model_id": primary_model.model_id,
+                "metadata": item.get("metadata"),
+            }
+
+    # Open results file for incremental writes if requested
+    results_fh = None
+    if results_file:
+        results_fh = open(results_file, "a")
+
+    try:
+        tasks = []
+        for i, item in enumerate(prompts):
+            if i in completed_indices:
+                # Already completed in a previous run — skip
+                results[i] = {"index": i, "skipped": True, "metadata": item.get("metadata")}
+                continue
+            tasks.append(_run_one(i, item))
+
+        completed = await asyncio.gather(*tasks)
+
+        for r in completed:
+            idx = r["index"]
+            results[idx] = r
+            if results_fh:
+                results_fh.write(_json.dumps(r) + "\n")
+                results_fh.flush()
+    finally:
+        if results_fh:
+            results_fh.close()
+
+    # Summary
+    succeeded = sum(1 for r in results if r.get("content") is not None and "error" not in r)
+    failed = sum(1 for r in results if "error" in r)
+    skipped = sum(1 for r in results if r.get("skipped"))
+
+    summary = {
+        "total": len(prompts),
+        "succeeded": succeeded,
+        "failed": failed,
+        "skipped": skipped,
+        "primary_model": primary_model.model_id,
+        "primary_model_label": primary_model.label,
+        "primary_provider": PROVIDERS[primary_model.provider].name,
+    }
+    if results_file:
+        summary["results_file"] = results_file
+
+    return {"summary": summary, "results": results}

--- a/src/model_radar/scanner.py
+++ b/src/model_radar/scanner.py
@@ -30,6 +30,45 @@ PING_PAYLOAD = {
 TIMEOUT_SECONDS = 10.0
 
 
+class ProviderThrottle:
+    """Tracks 429 errors per provider and computes exponential backoff delays."""
+
+    def __init__(self, max_delay: float = 16.0, window: float = 60.0):
+        self._recent_429s: dict[str, list[float]] = {}
+        self._max_delay = max_delay
+        self._window = window
+
+    def record_429(self, provider: str) -> None:
+        now = time.monotonic()
+        hits = self._recent_429s.setdefault(provider, [])
+        hits.append(now)
+        # Prune old entries outside window
+        self._recent_429s[provider] = [t for t in hits if now - t < self._window]
+
+    def record_success(self, provider: str) -> None:
+        hits = self._recent_429s.get(provider)
+        if hits:
+            # Decay: remove oldest entry on success
+            hits.pop(0)
+            if not hits:
+                del self._recent_429s[provider]
+
+    def should_throttle(self, provider: str) -> float:
+        """Returns delay in seconds (0 = no throttle)."""
+        now = time.monotonic()
+        hits = self._recent_429s.get(provider)
+        if not hits:
+            return 0.0
+        # Prune old entries
+        recent = [t for t in hits if now - t < self._window]
+        self._recent_429s[provider] = recent
+        if not recent:
+            return 0.0
+        # Exponential backoff: 1s, 2s, 4s, 8s, 16s based on hit count
+        delay = min(2 ** (len(recent) - 1), self._max_delay)
+        return delay
+
+
 @dataclass
 class PingResult:
     model: Model
@@ -44,6 +83,10 @@ class ScanState:
     ping_counts: dict[str, int] = field(default_factory=dict)
     success_counts: dict[str, int] = field(default_factory=dict)
     latency_sums: dict[str, float] = field(default_factory=dict)
+    # Verified-alive cache: model key → True (verified) or False (broken)
+    verified: dict[str, bool] = field(default_factory=dict)
+    # Per-provider rate limit tracker
+    throttle: ProviderThrottle = field(default_factory=ProviderThrottle)
 
     def record(self, key: str, success: bool, latency_ms: float | None):
         self.ping_counts[key] = self.ping_counts.get(key, 0) + 1
@@ -150,6 +193,72 @@ async def _ping_one(
         return PingResult(model=model, status="error", error_detail=str(e)[:100])
 
 
+VERIFY_PAYLOAD = {
+    "messages": [{"role": "user", "content": "Reply with exactly: OK"}],
+    "max_tokens": 5,
+    "temperature": 0,
+}
+
+
+async def _verify_one(
+    client: httpx.AsyncClient,
+    model: Model,
+    cfg: dict,
+    verify_prompt: str | None = None,
+) -> bool:
+    """Send a real prompt and check for non-empty content. Returns True if functional."""
+    api_key = get_api_key(cfg, model.provider)
+    if not api_key:
+        return False
+
+    url = _get_provider_url(model.provider, cfg)
+    if model.provider == "googleai":
+        url = f"{url}?key={api_key}"
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        if model.provider == "replicate":
+            headers["Authorization"] = f"Token {api_key}"
+        elif model.provider != "googleai":
+            headers["Authorization"] = f"Bearer {api_key}"
+
+    prompt_text = verify_prompt or "Reply with exactly: OK"
+    if model.provider == "replicate":
+        payload = {"input": {"prompt": prompt_text}, "version": model.model_id}
+    else:
+        payload = {
+            "model": model.model_id,
+            "messages": [{"role": "user", "content": prompt_text}],
+            "max_tokens": 5,
+            "temperature": 0,
+        }
+
+    try:
+        resp = await client.post(url, json=payload, headers=headers, timeout=TIMEOUT_SECONDS)
+        if resp.status_code not in (200, 201):
+            return False
+
+        data = resp.json()
+        if model.provider == "replicate":
+            output = data.get("output", [])
+            content = "".join(output) if isinstance(output, list) else str(output)
+        else:
+            choices = data.get("choices", [])
+            if not choices:
+                return False
+            msg = choices[0].get("message", {}) if isinstance(choices[0], dict) else {}
+            content = msg.get("content", "") or ""
+            if isinstance(content, list):
+                content = "".join(
+                    p.get("text", "") for p in content if isinstance(p, dict)
+                )
+
+        # Non-empty, non-whitespace content = functionally alive
+        return bool(content and content.strip())
+    except Exception:
+        return False
+
+
 async def scan_models(
     tier: str | None = None,
     provider: str | None = None,
@@ -158,6 +267,8 @@ async def scan_models(
     free_only: bool = False,
     limit: int = 0,
     state: ScanState | None = None,
+    verify: bool = False,
+    verify_prompt: str | None = None,
 ) -> list[PingResult]:
     """
     Ping models in parallel and return results sorted by latency.
@@ -191,9 +302,42 @@ async def scan_models(
             key = _model_key(r.model)
             state.record(key, r.status == "up", r.latency_ms)
 
+    # Verified-alive: send a real prompt to models marked "up" and check for content
+    if verify:
+        up_results = [r for r in results if r.status == "up"]
+        if up_results:
+            async with httpx.AsyncClient() as verify_client:
+                verify_tasks = []
+                for r in up_results:
+                    key = _model_key(r.model)
+                    # Use cache if available
+                    if state and key in state.verified:
+                        continue
+                    verify_tasks.append((r, _verify_one(verify_client, r.model, cfg, verify_prompt)))
+
+                if verify_tasks:
+                    verify_results = await asyncio.gather(
+                        *(t for _, t in verify_tasks)
+                    )
+                    for (r, _), is_alive in zip(verify_tasks, verify_results):
+                        key = _model_key(r.model)
+                        if not is_alive:
+                            r.status = "broken"
+                            r.error_detail = "verified_empty_response"
+                        if state:
+                            state.verified[key] = is_alive
+
+            # Apply cached verification results
+            if state:
+                for r in up_results:
+                    key = _model_key(r.model)
+                    if key in state.verified and not state.verified[key]:
+                        r.status = "broken"
+                        r.error_detail = "verified_empty_response"
+
     # Sort: up models by latency first, then others
     def sort_key(r: PingResult):
-        status_order = {"up": 0, "no_key": 1, "overloaded": 2, "timeout": 3, "error": 4, "not_found": 5}
+        status_order = {"up": 0, "no_key": 1, "overloaded": 2, "broken": 3, "timeout": 4, "error": 5, "not_found": 6}
         return (
             status_order.get(r.status, 9),
             r.latency_ms if r.latency_ms is not None else 999999,
@@ -216,6 +360,7 @@ def format_result(r: PingResult, state: ScanState | None = None) -> dict:
         "no_key": "NO_KEY",
         "timeout": "TIMEOUT",
         "overloaded": "OVERLOADED",
+        "broken": "BROKEN",
         "not_found": "NOT_FOUND",
         "error": "ERROR",
     }

--- a/src/model_radar/server.py
+++ b/src/model_radar/server.py
@@ -46,29 +46,37 @@ multiple models, and benchmark quality — all through MCP tools.
 - "Best model for coding" / "fastest model" → get_fastest(min_tier="A", count=5)
 - "Compare answers from several models" → ask(prompt, count=3)
 - "Refresh the model list from the internet" → refresh_models()
+- "Run these prompts in batch" → batch_run(prompts=[{"prompt": "..."}, ...])
+- "Check which models actually work" → scan(verify=True) or get_fastest(verified=True)
 
 ## Tool guide — Discovery
 - list_providers() — See all 17 providers and which have API keys. Call first when unsure.
 - list_models(tier?, provider?, min_tier?, free_only?) — Browse catalog without pinging. \
   model_id = code name to use when inserting/configuring (API, Cursor, run()); label = display only. \
   min_tier="A" means A or better. free_only=true for free only. Response includes is_free when known.
-- scan(...) — Ping models in parallel, get ranked by latency. Use when you need live speed data.
-- get_fastest(min_tier?, provider?, count?, free_only?) — Best N models right now. \
-  Example: get_fastest(free_only=True, min_tier="A", count=5) for "5 free A-or-better models".
+- scan(..., verify?) — Ping models in parallel, get ranked by latency. Use when you need live speed data. \
+  Set verify=true to also check models produce non-empty output (catches "ghost" models that ping UP but return empty content).
+- get_fastest(min_tier?, provider?, count?, free_only?, verified?) — Best N models right now. \
+  Example: get_fastest(free_only=True, min_tier="A", count=5) for "5 free A-or-better models". \
+  Set verified=true to exclude models that return empty responses.
 - provider_status() — Per-provider health check.
 
 ## Tool guide — Execution
 - run(prompt, free_only?, model_id?, provider?, min_tier?, ...) — Run a prompt on the fastest model. \
   Use free_only=true when the user wants a free model. Retries on next fastest if one fails.
 - ask(prompt, count=3, ...) — Run the same prompt on N models in parallel; compare responses.
+- batch_run(prompts, ...) — Run multiple prompts with bounded concurrency. For translation pipelines, \
+  data extraction, classification. Auto-retries failed items on alternate models. \
+  Set results_file for incremental JSONL output and resume support.
 
 ## Tool guide — Evaluation (LLM-as-judge)
 - judge(prompt, rubric, scale?, count?) — Rate a single item using N diverse judge models. \
   Returns aggregate scores, per-judge details, and inter-rater agreement.
 - compare(item_a, item_b, context?, dimensions?, judge_count?) — Blind A/B comparison by N judges. \
   Randomizes item order per judge to prevent position bias.
-- batch_judge(items, rubric, scale?, judge_count?, concurrency?) — Run evaluations at scale. \
-  Processes items with bounded concurrency and returns summary statistics.
+- batch_judge(items, rubric, scale?, judge_count?, concurrency?, results_file?) — Run evaluations at scale. \
+  Processes items with bounded concurrency and returns summary statistics. \
+  Set results_file for incremental JSONL output and automatic resume on interruption.
 
 ## Tool guide — Quality & Setup
 - refresh_models(provider?, run_ping?, ping_limit?) — Fetch latest model lists from APIs; \
@@ -200,10 +208,17 @@ async def scan(
     configured_only: bool = False,
     free_only: bool = False,
     limit: int = 20,
+    verify: bool = False,
+    verify_prompt: str | None = None,
 ) -> str:
     """Ping models in parallel and return ranked results by latency. Use when you need live speed data or a ranked list.
 
     Pings all matching models, returns sorted fastest-first. Takes 2-10 seconds depending on filters.
+
+    When verify=True, sends a real prompt to each "up" model and checks for non-empty
+    content. Models that return empty/garbage are marked as BROKEN (distinct from ERROR
+    or OVERLOADED). This catches models that ping as UP but are functionally dead.
+    Verification results are cached across scans within the session.
 
     Args:
         tier: Filter to exact tier (S+, S, A+, A, A-, B+, B, C)
@@ -212,10 +227,13 @@ async def scan(
         configured_only: Only ping models whose provider has an API key
         free_only: Only include models marked as free (from API or :free/-free in id)
         limit: Max results (default 20, 0 = all)
+        verify: Send a real prompt to validate non-empty content (default false)
+        verify_prompt: Custom verification prompt (default "Reply with exactly: OK")
     """
     results = await scan_models(
         tier=tier, provider=provider, min_tier=min_tier,
         configured_only=configured_only, free_only=free_only, limit=limit, state=_state,
+        verify=verify, verify_prompt=verify_prompt,
     )
     rows = [format_result(r, _state) for r in results]
 
@@ -234,23 +252,29 @@ async def get_fastest(
     provider: str | None = None,
     count: int = 5,
     free_only: bool = False,
+    verified: bool = False,
 ) -> str:
     """Get the N fastest available models right now. Use when the user wants recommendations or \"best/fastest/free\" models.
 
     Pings configured providers and returns top N by latency. Use model_id from results as the code name when inserting or configuring (e.g. run(prompt, model_id=..., provider=...)). Example: get_fastest(free_only=True, min_tier=\"A\", count=5) for \"5 free A-or-better models\".
+
+    When verified=True, also sends a real prompt to each model to confirm it produces
+    non-empty output. Models that ping as UP but return empty content are excluded.
 
     Args:
         min_tier: Minimum quality tier (default "A" — shows S+, S, A+, A)
         provider: Limit to specific provider
         count: How many results (default 5)
         free_only: If true, only return models marked as free
+        verified: If true, verify models produce non-empty output (default false)
     """
     results = await scan_models(
         min_tier=min_tier, provider=provider,
-        configured_only=True, free_only=free_only, limit=count, state=_state,
+        configured_only=True, free_only=free_only, limit=count * 2 if verified else count,
+        state=_state, verify=verified,
     )
     # Only return models that are actually up
-    up_results = [r for r in results if r.status == "up"]
+    up_results = [r for r in results if r.status == "up"][:count]
     rows = [format_result(r, _state) for r in up_results]
 
     if not rows:
@@ -493,6 +517,65 @@ async def ask(
 
 
 @mcp.tool()
+async def batch_run(
+    prompts: list[dict],
+    system_prompt: str | None = None,
+    model_id: str | None = None,
+    provider: str | None = None,
+    min_tier: str = "A",
+    free_only: bool = False,
+    max_tokens: int = 4096,
+    temperature: float = 0.0,
+    concurrency: int = 5,
+    retry_on_fail: bool = True,
+    results_file: str | None = None,
+) -> str:
+    """Run multiple prompts in parallel with bounded concurrency and auto-retry.
+
+    For batch workloads: translation pipelines, data extraction, classification,
+    content generation. Picks the fastest model and runs all prompts through it.
+    Failed items are automatically retried on alternate models.
+
+    Each prompt dict should have a "prompt" key and optional "system_prompt"
+    (overrides the top-level system_prompt) and "metadata" keys for tracking.
+
+    When results_file is set, each completed item is appended as a JSON line
+    immediately. If interrupted, the file contains all completed items and
+    can be resumed (already-completed indices are skipped).
+
+    Args:
+        prompts: List of {"prompt": "...", "system_prompt": "...", "metadata": {...}}
+        system_prompt: Default system prompt for all items (per-item overrides)
+        model_id: Specific model to use (skips scanning). Use list_models() to browse.
+        provider: Limit to a specific provider
+        min_tier: Minimum quality tier when auto-selecting (default "A")
+        free_only: If true, only use free models
+        max_tokens: Max response tokens per item (default 4096)
+        temperature: Sampling temperature (default 0.0)
+        concurrency: Max parallel requests (default 5)
+        retry_on_fail: Auto-retry failed items on alternate models (default true)
+        results_file: Path to JSONL file for incremental writes and resume support
+    """
+    from .runner import batch_run as _batch_run
+
+    result = await _batch_run(
+        prompts=prompts,
+        system_prompt=system_prompt,
+        model_id=model_id,
+        provider=provider,
+        min_tier=min_tier,
+        free_only=free_only,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        concurrency=concurrency,
+        retry_on_fail=retry_on_fail,
+        results_file=results_file,
+        state=_state,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
 async def judge(
     prompt: str,
     rubric: list[str],
@@ -608,6 +691,7 @@ async def batch_judge(
     concurrency: int = 5,
     max_tokens: int = 256,
     temperature: float = 0.0,
+    results_file: str | None = None,
 ) -> str:
     """Run judge evaluations at scale on a list of items.
 
@@ -618,6 +702,11 @@ async def batch_judge(
     Each item in the list should have a "prompt" key with the evaluation
     prompt, and an optional "metadata" key for tracking (e.g. language,
     entry ID).
+
+    When results_file is set, each scored item is appended as a JSON line
+    immediately after scoring. On interruption, the file contains all
+    completed items. On resume (same results_file), already-scored indices
+    are skipped automatically.
 
     Args:
         items: List of {"prompt": "...", "metadata": {...}} dicts
@@ -630,6 +719,7 @@ async def batch_judge(
         concurrency: Max items evaluated in parallel (default 5)
         max_tokens: Max response tokens per judge (default 256)
         temperature: Sampling temperature (default 0.0)
+        results_file: Path to JSONL file for incremental writes and resume support
     """
     from .judge import batch_judge_items
 
@@ -645,6 +735,7 @@ async def batch_judge(
         max_tokens=max_tokens,
         temperature=temperature,
         state=_state,
+        results_file=results_file,
     )
     return json.dumps(result, indent=2)
 

--- a/src/model_radar/server.py
+++ b/src/model_radar/server.py
@@ -62,6 +62,14 @@ multiple models, and benchmark quality — all through MCP tools.
   Use free_only=true when the user wants a free model. Retries on next fastest if one fails.
 - ask(prompt, count=3, ...) — Run the same prompt on N models in parallel; compare responses.
 
+## Tool guide — Evaluation (LLM-as-judge)
+- judge(prompt, rubric, scale?, count?) — Rate a single item using N diverse judge models. \
+  Returns aggregate scores, per-judge details, and inter-rater agreement.
+- compare(item_a, item_b, context?, dimensions?, judge_count?) — Blind A/B comparison by N judges. \
+  Randomizes item order per judge to prevent position bias.
+- batch_judge(items, rubric, scale?, judge_count?, concurrency?) — Run evaluations at scale. \
+  Processes items with bounded concurrency and returns summary statistics.
+
 ## Tool guide — Quality & Setup
 - refresh_models(provider?, run_ping?, ping_limit?) — Fetch latest model lists from APIs; \
   use periodically so free/paid and model list stay current.
@@ -477,6 +485,163 @@ async def ask(
         count=count,
         min_tier=min_tier,
         provider=provider,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        state=_state,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+async def judge(
+    prompt: str,
+    rubric: list[str],
+    scale: str = "1-5",
+    count: int = 3,
+    min_tier: str = "A",
+    free_only: bool = False,
+    output_format: str = "csv",
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+) -> str:
+    """Rate a single item using N diverse judge models and return aggregate scores.
+
+    Auto-selects judges spread across different providers for independence.
+    Enforces structured output (CSV or JSON scores), retries on malformed
+    responses, and computes inter-rater agreement metrics.
+
+    Use this for evaluation tasks: rating translations, code quality,
+    content accuracy, or any rubric-based assessment.
+
+    Args:
+        prompt: The evaluation prompt (describe what to rate and provide the content)
+        rubric: List of scoring dimensions (e.g. ["accuracy", "naturalness", "completeness"])
+        scale: Rating scale as "min-max" (default "1-5", also supports "1-10")
+        count: Number of judge models to use (default 3)
+        min_tier: Minimum quality tier for judge selection (default "A")
+        free_only: If true, only use free models as judges
+        output_format: How judges format scores — "csv" (default) or "json"
+        max_tokens: Max response tokens per judge (default 256)
+        temperature: Sampling temperature (default 0.0)
+    """
+    from .judge import judge_item
+
+    result = await judge_item(
+        prompt=prompt,
+        rubric=rubric,
+        scale=scale,
+        count=count,
+        min_tier=min_tier,
+        free_only=free_only,
+        output_format=output_format,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        state=_state,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+async def compare(
+    item_a: str,
+    item_b: str,
+    context: str | None = None,
+    dimensions: list[str] | None = None,
+    scale: str = "1-5",
+    judge_count: int = 3,
+    blind: bool = True,
+    min_tier: str = "A",
+    free_only: bool = False,
+    max_tokens: int = 512,
+    temperature: float = 0.0,
+) -> str:
+    """Blind A/B comparison of two items judged by N models.
+
+    When blind=True (default), randomizes which item is shown as A vs B
+    to each judge independently, then de-randomizes scores. This prevents
+    position bias where judges consistently favor the first item shown.
+
+    Use for comparing translations, code solutions, summaries, or any
+    pair of outputs where you want an objective preference.
+
+    Args:
+        item_a: First item to compare
+        item_b: Second item to compare
+        context: Optional context for the comparison (e.g. the original task)
+        dimensions: Scoring dimensions (default ["quality"])
+        scale: Rating scale as "min-max" (default "1-5")
+        judge_count: Number of judge models (default 3)
+        blind: Randomize A/B order per judge to prevent position bias (default true)
+        min_tier: Minimum quality tier for judge selection (default "A")
+        free_only: If true, only use free models as judges
+        max_tokens: Max response tokens per judge (default 512)
+        temperature: Sampling temperature (default 0.0)
+    """
+    from .judge import compare_items
+
+    result = await compare_items(
+        item_a=item_a,
+        item_b=item_b,
+        context=context,
+        dimensions=dimensions,
+        scale=scale,
+        judge_count=judge_count,
+        blind=blind,
+        min_tier=min_tier,
+        free_only=free_only,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        state=_state,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+async def batch_judge(
+    items: list[dict],
+    rubric: list[str],
+    scale: str = "1-5",
+    judge_count: int = 3,
+    min_tier: str = "A",
+    free_only: bool = False,
+    output_format: str = "csv",
+    concurrency: int = 5,
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+) -> str:
+    """Run judge evaluations at scale on a list of items.
+
+    Processes items with bounded concurrency using a shared pool of diverse
+    judges. Returns per-item scores, summary statistics (mean, stdev, min,
+    max per dimension), and error counts.
+
+    Each item in the list should have a "prompt" key with the evaluation
+    prompt, and an optional "metadata" key for tracking (e.g. language,
+    entry ID).
+
+    Args:
+        items: List of {"prompt": "...", "metadata": {...}} dicts
+        rubric: List of scoring dimensions (e.g. ["accuracy", "naturalness"])
+        scale: Rating scale as "min-max" (default "1-5")
+        judge_count: Judges per item (default 3)
+        min_tier: Minimum quality tier for judge selection (default "A")
+        free_only: If true, only use free models as judges
+        output_format: How judges format scores — "csv" (default) or "json"
+        concurrency: Max items evaluated in parallel (default 5)
+        max_tokens: Max response tokens per judge (default 256)
+        temperature: Sampling temperature (default 0.0)
+    """
+    from .judge import batch_judge_items
+
+    result = await batch_judge_items(
+        items=items,
+        rubric=rubric,
+        scale=scale,
+        judge_count=judge_count,
+        min_tier=min_tier,
+        free_only=free_only,
+        output_format=output_format,
+        concurrency=concurrency,
         max_tokens=max_tokens,
         temperature=temperature,
         state=_state,

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,0 +1,469 @@
+"""Tests for the judge (LLM-as-judge evaluation) module."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from model_radar.judge import (
+    _build_judge_system_prompt,
+    _compute_agreement,
+    _parse_compare_scores,
+    _parse_csv_scores,
+    _parse_json_scores,
+    _parse_scores,
+    _select_diverse_judges,
+    batch_judge_items,
+    compare_items,
+    judge_item,
+)
+from model_radar.providers import Model
+from model_radar.scanner import PingResult
+
+
+def _model(provider="nvidia", model_id="test/model-1", label="Model 1",
+           tier="A", swe="45.0%", ctx="128k"):
+    return Model(model_id=model_id, label=label, tier=tier,
+                 swe_score=swe, context=ctx, provider=provider)
+
+
+def _make_response(model, content):
+    return {
+        "content": content,
+        "model_id": model.model_id,
+        "model_label": model.label,
+        "provider": "NIM",
+        "provider_key": model.provider,
+        "tier": model.tier,
+        "latency_ms": 500.0,
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+
+
+# --- Score parsing tests ---
+
+class TestParseCSVScores:
+    def test_simple_csv(self):
+        result = _parse_csv_scores("4,5,3", ["accuracy", "naturalness", "completeness"], "1-5")
+        assert result == {"accuracy": 4.0, "naturalness": 5.0, "completeness": 3.0}
+
+    def test_csv_with_spaces(self):
+        result = _parse_csv_scores("4, 5, 3", ["a", "b", "c"], "1-5")
+        assert result == {"a": 4.0, "b": 5.0, "c": 3.0}
+
+    def test_csv_with_backticks(self):
+        result = _parse_csv_scores("`4,5,3`", ["a", "b", "c"], "1-5")
+        assert result == {"a": 4.0, "b": 5.0, "c": 3.0}
+
+    def test_csv_out_of_range(self):
+        result = _parse_csv_scores("4,6,3", ["a", "b", "c"], "1-5")
+        assert result is None
+
+    def test_csv_too_few_numbers(self):
+        result = _parse_csv_scores("4,5", ["a", "b", "c"], "1-5")
+        assert result is None
+
+    def test_csv_extra_numbers(self):
+        """Extra numbers should be ignored."""
+        result = _parse_csv_scores("4,5,3,2", ["a", "b", "c"], "1-5")
+        assert result == {"a": 4.0, "b": 5.0, "c": 3.0}
+
+    def test_csv_float_scores(self):
+        result = _parse_csv_scores("4.5,3.2", ["a", "b"], "1-5")
+        assert result == {"a": 4.5, "b": 3.2}
+
+    def test_csv_1_to_10_scale(self):
+        result = _parse_csv_scores("8,9", ["a", "b"], "1-10")
+        assert result == {"a": 8.0, "b": 9.0}
+
+    def test_csv_invalid_scale(self):
+        result = _parse_csv_scores("4,5", ["a", "b"], "bad")
+        assert result is None
+
+
+class TestParseJSONScores:
+    def test_simple_json(self):
+        result = _parse_json_scores('{"accuracy": 4, "naturalness": 5}',
+                                     ["accuracy", "naturalness"], "1-5")
+        assert result == {"accuracy": 4.0, "naturalness": 5.0}
+
+    def test_json_with_surrounding_text(self):
+        result = _parse_json_scores('Here are the scores: {"a": 4, "b": 5}',
+                                     ["a", "b"], "1-5")
+        assert result == {"a": 4.0, "b": 5.0}
+
+    def test_json_case_insensitive(self):
+        result = _parse_json_scores('{"Accuracy": 4, "Naturalness": 5}',
+                                     ["accuracy", "naturalness"], "1-5")
+        assert result == {"accuracy": 4.0, "naturalness": 5.0}
+
+    def test_json_missing_dimension(self):
+        result = _parse_json_scores('{"accuracy": 4}',
+                                     ["accuracy", "naturalness"], "1-5")
+        assert result is None
+
+    def test_json_out_of_range(self):
+        result = _parse_json_scores('{"a": 4, "b": 6}', ["a", "b"], "1-5")
+        assert result is None
+
+
+class TestParseScores:
+    def test_csv_format(self):
+        result = _parse_scores("4,5", ["a", "b"], "1-5", "csv")
+        assert result == {"a": 4.0, "b": 5.0}
+
+    def test_json_format(self):
+        result = _parse_scores('{"a": 4, "b": 5}', ["a", "b"], "1-5", "json")
+        assert result == {"a": 4.0, "b": 5.0}
+
+
+# --- System prompt tests ---
+
+class TestBuildJudgeSystemPrompt:
+    def test_csv_prompt(self):
+        prompt = _build_judge_system_prompt(["accuracy", "naturalness"], "1-5", "csv")
+        assert "2 numbers" in prompt
+        assert "accuracy, naturalness" in prompt
+        assert "1-5" in prompt
+        assert "commas" in prompt
+
+    def test_json_prompt(self):
+        prompt = _build_judge_system_prompt(["quality"], "1-10", "json")
+        assert "JSON" in prompt
+        assert "quality" in prompt
+
+
+# --- Agreement metrics tests ---
+
+class TestComputeAgreement:
+    def test_two_judges_agreement(self):
+        per_judge = [
+            {"scores": {"a": 4.0, "b": 5.0}},
+            {"scores": {"a": 4.0, "b": 4.0}},
+        ]
+        result = _compute_agreement(per_judge, ["a", "b"])
+        assert result["mean_pairwise_diff"] is not None
+        assert result["per_dimension"]["a"] == 0.0
+        assert result["per_dimension"]["b"] == 1.0
+
+    def test_three_judges_includes_stdev(self):
+        per_judge = [
+            {"scores": {"a": 4.0}},
+            {"scores": {"a": 5.0}},
+            {"scores": {"a": 3.0}},
+        ]
+        result = _compute_agreement(per_judge, ["a"])
+        assert "stdev" in result
+        assert "a" in result["stdev"]
+
+    def test_single_judge_returns_note(self):
+        per_judge = [{"scores": {"a": 4.0}}]
+        result = _compute_agreement(per_judge, ["a"])
+        assert "note" in result
+
+
+# --- Compare score parsing tests ---
+
+class TestParseCompareScores:
+    def test_two_lines(self):
+        content = "A: 4,5\nB: 3,4"
+        a, b = _parse_compare_scores(content, ["x", "y"], "1-5", ("A", "B"))
+        assert a == {"x": 4.0, "y": 5.0}
+        assert b == {"x": 3.0, "y": 4.0}
+
+    def test_no_labels(self):
+        content = "4,5\n3,4"
+        a, b = _parse_compare_scores(content, ["x", "y"], "1-5", ("A", "B"))
+        assert a == {"x": 4.0, "y": 5.0}
+        assert b == {"x": 3.0, "y": 4.0}
+
+    def test_malformed(self):
+        a, b = _parse_compare_scores("garbage", ["x"], "1-5", ("A", "B"))
+        assert a is None
+        assert b is None
+
+
+# --- Diverse judge selection tests ---
+
+@pytest.mark.asyncio
+async def test_select_diverse_judges_different_providers():
+    """Should prefer models from different providers."""
+    models = [
+        _model(provider="nvidia", model_id="m1", label="M1"),
+        _model(provider="nvidia", model_id="m2", label="M2"),
+        _model(provider="groq", model_id="m3", label="M3"),
+        _model(provider="cerebras", model_id="m4", label="M4"),
+    ]
+    ping_results = [PingResult(model=m, status="up", latency_ms=100) for m in models]
+
+    with patch("model_radar.judge.scan_models", return_value=ping_results):
+        judges = await _select_diverse_judges(count=3)
+
+    providers = {j.provider for j in judges}
+    assert len(judges) == 3
+    # Should pick one from each of 3 different providers
+    assert len(providers) == 3
+
+
+@pytest.mark.asyncio
+async def test_select_diverse_judges_fills_from_same_provider():
+    """Should fill remaining slots from same provider if not enough providers."""
+    models = [
+        _model(provider="nvidia", model_id="m1", label="M1"),
+        _model(provider="nvidia", model_id="m2", label="M2"),
+    ]
+    ping_results = [PingResult(model=m, status="up", latency_ms=100) for m in models]
+
+    with patch("model_radar.judge.scan_models", return_value=ping_results):
+        judges = await _select_diverse_judges(count=2)
+
+    assert len(judges) == 2
+
+
+@pytest.mark.asyncio
+async def test_select_diverse_judges_no_models():
+    """Should return empty list when no models available."""
+    with patch("model_radar.judge.scan_models", return_value=[]):
+        judges = await _select_diverse_judges(count=3)
+
+    assert judges == []
+
+
+# --- judge_item tests ---
+
+@pytest.mark.asyncio
+async def test_judge_item_basic():
+    """Should return aggregate scores from multiple judges."""
+    judges = [
+        _model(provider="nvidia", model_id="m1", label="Judge 1"),
+        _model(provider="groq", model_id="m2", label="Judge 2"),
+        _model(provider="cerebras", model_id="m3", label="Judge 3"),
+    ]
+
+    async def mock_call(model, messages, cfg, max_tokens, temperature):
+        return _make_response(model, "4,5,3")
+
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=judges), \
+         patch("model_radar.judge._call_model", side_effect=mock_call):
+        result = await judge_item(
+            prompt="Rate this translation",
+            rubric=["accuracy", "naturalness", "completeness"],
+            scale="1-5",
+            count=3,
+        )
+
+    assert result["judges_succeeded"] == 3
+    assert result["errors"] == 0
+    assert result["scores"]["accuracy"] == 4.0
+    assert result["scores"]["naturalness"] == 5.0
+    assert result["scores"]["completeness"] == 3.0
+    assert len(result["judges_used"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_judge_item_partial_failure():
+    """Should handle some judges failing."""
+    judges = [
+        _model(provider="nvidia", model_id="m1", label="Judge 1"),
+        _model(provider="groq", model_id="m2", label="Judge 2"),
+    ]
+
+    call_count = 0
+    async def mock_call(model, messages, cfg, max_tokens, temperature):
+        nonlocal call_count
+        call_count += 1
+        if model.model_id == "m1":
+            return _make_response(model, "4,5")
+        return {"error": "HTTP 429", "model": model.label, "provider": "Groq"}
+
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=judges), \
+         patch("model_radar.judge._call_model", side_effect=mock_call):
+        result = await judge_item(
+            prompt="Rate this",
+            rubric=["accuracy", "naturalness"],
+            scale="1-5",
+            count=2,
+        )
+
+    assert result["judges_succeeded"] == 1
+    assert result["errors"] == 1
+    assert result["scores"]["accuracy"] == 4.0
+
+
+@pytest.mark.asyncio
+async def test_judge_item_empty_rubric():
+    """Should return error for empty rubric."""
+    result = await judge_item(prompt="test", rubric=[], count=1)
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_judge_item_no_models():
+    """Should return error when no judges available."""
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=[]):
+        result = await judge_item(prompt="test", rubric=["quality"], count=3)
+
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_judge_item_malformed_output():
+    """Should report malformed output as error after retries."""
+    judges = [_model(provider="nvidia", model_id="m1", label="Judge 1")]
+
+    async def mock_call(model, messages, cfg, max_tokens, temperature):
+        return _make_response(model, "This is not a valid score format")
+
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=judges), \
+         patch("model_radar.judge._call_model", side_effect=mock_call):
+        result = await judge_item(
+            prompt="Rate this",
+            rubric=["accuracy", "naturalness"],
+            scale="1-5",
+            count=1,
+        )
+
+    assert result["errors"] == 1
+    assert result["judges_succeeded"] == 0
+
+
+# --- compare_items tests ---
+
+@pytest.mark.asyncio
+async def test_compare_items_basic():
+    """Should compare two items and pick a winner."""
+    judges = [
+        _model(provider="nvidia", model_id="m1", label="Judge 1"),
+        _model(provider="groq", model_id="m2", label="Judge 2"),
+    ]
+
+    async def mock_call(model, messages, cfg, max_tokens, temperature):
+        return _make_response(model, "A: 5\nB: 3")
+
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=judges), \
+         patch("model_radar.judge._call_model", side_effect=mock_call), \
+         patch("model_radar.judge.random") as mock_random:
+        # No swapping for deterministic test
+        mock_random.random.return_value = 0.9
+        result = await compare_items(
+            item_a="Translation A",
+            item_b="Translation B",
+            dimensions=["quality"],
+            judge_count=2,
+            blind=True,
+        )
+
+    assert result["winner"] == "A"
+    assert result["wins"]["A"] == 2
+    assert result["judges_succeeded"] == 2
+
+
+@pytest.mark.asyncio
+async def test_compare_items_no_models():
+    """Should return error when no judges available."""
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=[]):
+        result = await compare_items(
+            item_a="A", item_b="B", judge_count=3,
+        )
+
+    assert "error" in result
+
+
+# --- batch_judge_items tests ---
+
+@pytest.mark.asyncio
+async def test_batch_judge_basic():
+    """Should process multiple items and return summary stats."""
+    judges = [
+        _model(provider="nvidia", model_id="m1", label="Judge 1"),
+        _model(provider="groq", model_id="m2", label="Judge 2"),
+    ]
+
+    async def mock_call(model, messages, cfg, max_tokens, temperature):
+        return _make_response(model, "4,5")
+
+    items = [
+        {"prompt": "Rate item 1", "metadata": {"id": 1}},
+        {"prompt": "Rate item 2", "metadata": {"id": 2}},
+        {"prompt": "Rate item 3", "metadata": {"id": 3}},
+    ]
+
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=judges), \
+         patch("model_radar.judge._call_model", side_effect=mock_call):
+        result = await batch_judge_items(
+            items=items,
+            rubric=["accuracy", "naturalness"],
+            scale="1-5",
+            judge_count=2,
+        )
+
+    assert result["items_total"] == 3
+    assert result["items_scored"] == 3
+    assert result["items_errored"] == 0
+    assert len(result["results"]) == 3
+    assert "accuracy" in result["summary"]
+    assert result["summary"]["accuracy"]["mean"] == 4.0
+
+
+@pytest.mark.asyncio
+async def test_batch_judge_empty_items():
+    """Should return error for empty items list."""
+    result = await batch_judge_items(items=[], rubric=["quality"])
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_batch_judge_empty_rubric():
+    """Should return error for empty rubric."""
+    result = await batch_judge_items(
+        items=[{"prompt": "test"}], rubric=[]
+    )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_batch_judge_missing_prompt():
+    """Should handle items with missing prompt."""
+    judges = [_model(provider="nvidia", model_id="m1", label="Judge 1")]
+
+    async def mock_call(model, messages, cfg, max_tokens, temperature):
+        return _make_response(model, "4")
+
+    items = [
+        {"metadata": {"id": 1}},  # missing prompt
+        {"prompt": "Rate this", "metadata": {"id": 2}},
+    ]
+
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=judges), \
+         patch("model_radar.judge._call_model", side_effect=mock_call):
+        result = await batch_judge_items(
+            items=items,
+            rubric=["quality"],
+            scale="1-5",
+            judge_count=1,
+        )
+
+    assert result["items_total"] == 2
+    assert result["items_errored"] == 1
+    assert result["items_scored"] == 1
+
+
+@pytest.mark.asyncio
+async def test_batch_judge_no_models():
+    """Should return error when no judges available."""
+    with patch("model_radar.judge.load_config", return_value={"api_keys": {}, "providers": {}}), \
+         patch("model_radar.judge._select_diverse_judges", return_value=[]):
+        result = await batch_judge_items(
+            items=[{"prompt": "test"}],
+            rubric=["quality"],
+            judge_count=3,
+        )
+
+    assert "error" in result


### PR DESCRIPTION
Closes #3

## Summary

- **Judge tools exposed as MCP tools**: Cherry-picked `judge()`, `compare()`, and `batch_judge()` from the issue-1 branch — structured LLM-as-judge evaluation with provider-diverse judge selection, inter-rater agreement, and blind A/B comparison with position bias detection.
- **`batch_run()` tool**: New MCP tool for running multiple prompts with bounded concurrency, auto-retry on alternate models, and optional JSONL incremental output with resume support.
- **Verified-alive scan**: `scan(verify=True)` and `get_fastest(verified=True)` send a real prompt to each model and check for non-empty content. Models that ping UP but return empty responses are marked `BROKEN` — catches "ghost" models like GPT-OSS-120B on Groq.
- **Adaptive per-provider rate limiting**: `ProviderThrottle` class with exponential backoff (1s→16s) on 429 errors, integrated into `_call_model()` so all tools (`run`, `ask`, `judge`, `batch_run`) benefit automatically.
- **Incremental JSONL results**: `batch_judge(results_file=...)` and `batch_run(results_file=...)` append each completed item as a JSON line immediately. On interruption, completed items are preserved. On resume, already-completed indices are skipped.

## Test plan

- [x] All existing tests pass (1 pre-existing failure in `test_list_models_tool` due to missing xai provider — not caused by this PR)
- [x] All new modules import cleanly
- [ ] Manual test: `scan(verify=True)` on configured providers
- [ ] Manual test: `batch_run` with a few prompts
- [ ] Manual test: `judge` / `compare` / `batch_judge` tools via MCP