### PR TITLE
feat: lessons learned — think-tag stripping, script purity, cost aggregation

### DIFF
--- a/src/model_radar/judge.py
+++ b/src/model_radar/judge.py
@@ -23,6 +23,7 @@ from .providers import PROVIDERS, Model
 from .quality import get_model_quality
 from .runner import _call_model
 from .scanner import ScanState, scan_models
+from .text_utils import strip_think_tags
 
 
 def _build_judge_system_prompt(
@@ -207,6 +208,8 @@ async def _call_judge_with_retry(
             return {"error": result["error"], "model": model, "raw": result}
 
         content = result.get("content", "")
+        # Strip think tags (Qwen3 etc.) before parsing structured output
+        content, _thinking = strip_think_tags(content)
         if not content:
             if attempt < max_retries:
                 continue
@@ -700,19 +703,6 @@ async def batch_judge_items(
 
     Processes items with bounded concurrency. Returns results incrementally
     so partial progress is available even if interrupted.
-
-    Args:
-        items: List of dicts with "prompt" key (and optional "metadata")
-        rubric: List of dimension names
-        scale: Rating scale
-        judge_count: Judges per item
-        min_tier: Minimum quality tier for judge selection
-        free_only: Only use free models
-        output_format: "csv" or "json"
-        concurrency: Max items evaluated in parallel
-        max_tokens: Max response tokens per judge
-        temperature: Sampling temperature
-        state: Shared scan state
 
     Args:
         items: List of dicts with "prompt" key (and optional "metadata")

--- a/src/model_radar/runner.py
+++ b/src/model_radar/runner.py
@@ -17,6 +17,7 @@ import httpx
 from .config import get_api_key, load_config
 from .providers import PROVIDERS, Model
 from .scanner import ProviderThrottle, ScanState, scan_models
+from .text_utils import strip_think_tags
 
 # Module-level throttle instance shared across all calls
 _throttle = ProviderThrottle()
@@ -135,6 +136,9 @@ async def _call_model(
                     elif isinstance(part, str):
                         content += part
 
+    # Strip think tags (Qwen3, etc.) — extract reasoning and return clean content
+    content, think_content = strip_think_tags(content)
+
     # Expose full raw API response body for debugging
     raw_response = data if resp.status_code in (200, 201) else None
 
@@ -152,6 +156,8 @@ async def _call_model(
             "total_tokens": usage.get("total_tokens"),
         },
     }
+    if think_content:
+        out["think_content"] = think_content
     if raw_response is not None:
         out["raw_response"] = raw_response
     return out
@@ -307,7 +313,13 @@ async def batch_run(
         if not up_models:
             return {"error": "No models available. Check API keys with list_providers()."}
         primary_model = up_models[0]
-        fallback_models = up_models[1:4] if retry_on_fail else []
+        if retry_on_fail:
+            # Prefer fallback models from different providers for resilience
+            diff_provider = [m for m in up_models[1:] if m.provider != primary_model.provider]
+            same_provider = [m for m in up_models[1:] if m.provider == primary_model.provider]
+            fallback_models = (diff_provider + same_provider)[:4]
+        else:
+            fallback_models = []
 
     semaphore = asyncio.Semaphore(concurrency)
 
@@ -415,6 +427,14 @@ async def batch_run(
     failed = sum(1 for r in results if "error" in r)
     skipped = sum(1 for r in results if r.get("skipped"))
 
+    # Aggregate token usage across all results
+    total_prompt_tokens = 0
+    total_completion_tokens = 0
+    for r in results:
+        usage = r.get("usage") or {}
+        total_prompt_tokens += usage.get("prompt_tokens") or 0
+        total_completion_tokens += usage.get("completion_tokens") or 0
+
     summary = {
         "total": len(prompts),
         "succeeded": succeeded,
@@ -423,6 +443,11 @@ async def batch_run(
         "primary_model": primary_model.model_id,
         "primary_model_label": primary_model.label,
         "primary_provider": PROVIDERS[primary_model.provider].name,
+        "usage": {
+            "total_prompt_tokens": total_prompt_tokens,
+            "total_completion_tokens": total_completion_tokens,
+            "total_tokens": total_prompt_tokens + total_completion_tokens,
+        },
     }
     if results_file:
         summary["results_file"] = results_file

--- a/src/model_radar/text_utils.py
+++ b/src/model_radar/text_utils.py
@@ -1,0 +1,232 @@
+"""
+Text processing utilities for model responses.
+
+Handles think-tag stripping, script purity validation, and prompt-echo detection.
+These address real-world issues discovered in large-scale translation and evaluation
+pipelines (see issue #5).
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# ---------------------------------------------------------------------------
+# Think-tag stripping
+# ---------------------------------------------------------------------------
+
+# Matches <think>...</think> blocks (greedy, dotall).  Some models emit
+# multiline reasoning inside these tags before producing the actual answer.
+_THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+
+# Also strip incomplete think blocks (model hit max_tokens inside <think>)
+_INCOMPLETE_THINK_RE = re.compile(r"<think>.*", re.DOTALL)
+
+
+def strip_think_tags(content: str) -> tuple[str, str | None]:
+    """Strip ``<think>...</think>`` tags from model output.
+
+    Returns:
+        (cleaned_content, thinking_text) — thinking_text is the raw text
+        inside the tags (or None if no tags were found).
+    """
+    if not content or "<think>" not in content:
+        return content, None
+
+    # Extract thinking content for metadata
+    think_match = re.search(r"<think>(.*?)</think>", content, re.DOTALL)
+    thinking = think_match.group(1).strip() if think_match else None
+
+    # Strip complete <think>...</think> blocks
+    cleaned = _THINK_RE.sub("", content)
+
+    # If there's still an unclosed <think> (hit max_tokens), strip it too
+    if "<think>" in cleaned:
+        incomplete = re.search(r"<think>(.*)", cleaned, re.DOTALL)
+        if incomplete and thinking is None:
+            thinking = incomplete.group(1).strip()
+        cleaned = _INCOMPLETE_THINK_RE.sub("", cleaned)
+
+    cleaned = cleaned.strip()
+    return cleaned, thinking
+
+
+# ---------------------------------------------------------------------------
+# Script purity validation
+# ---------------------------------------------------------------------------
+
+# Expected Unicode script ranges for common languages.
+# Each entry maps a language code to the Unicode categories / script ranges
+# that are expected in output for that language.  Characters outside these
+# ranges (excluding punctuation, digits, whitespace) are "leakage".
+_SCRIPT_RANGES: dict[str, set[str]] = {
+    # CJK languages — expect CJK Unified Ideographs + script-specific ranges
+    "zh": {"Han", "Latin"},
+    "ja": {"Han", "Hiragana", "Katakana", "Latin"},
+    "ko": {"Hangul", "Latin"},
+    # Latin-script languages
+    "en": {"Latin"},
+    "de": {"Latin"},
+    "fr": {"Latin"},
+    "es": {"Latin"},
+    "pt": {"Latin"},
+    "id": {"Latin"},
+    "vi": {"Latin"},
+    # Cyrillic
+    "ru": {"Cyrillic", "Latin"},
+    "uk": {"Cyrillic", "Latin"},
+    # Arabic-script
+    "ar": {"Arabic", "Latin"},
+    "fa": {"Arabic", "Latin"},
+    # Devanagari
+    "hi": {"Devanagari", "Latin"},
+    # Thai
+    "th": {"Thai", "Latin"},
+    # Greek
+    "el": {"Greek", "Latin"},
+    # Hebrew
+    "he": {"Hebrew", "Latin"},
+    # Armenian
+    "hy": {"Armenian", "Latin"},
+    # Georgian
+    "ka": {"Georgian", "Latin"},
+    # Ethiopic
+    "am": {"Ethiopic", "Latin"},
+    # Korean already above
+}
+
+
+def _char_script(ch: str) -> str | None:
+    """Return the Unicode script name for a character, or None for common chars."""
+    cat = unicodedata.category(ch)
+    # Skip punctuation, digits, whitespace, symbols, marks
+    if cat[0] in ("P", "N", "Z", "S", "M", "C"):
+        return None
+
+    # Use Unicode script property via name heuristic
+    try:
+        name = unicodedata.name(ch, "")
+    except ValueError:
+        return None
+
+    if not name:
+        return None
+
+    # Map character name prefixes to script names
+    name_upper = name.upper()
+    scripts = [
+        ("CJK", "Han"),
+        ("HANGUL", "Hangul"),
+        ("HIRAGANA", "Hiragana"),
+        ("KATAKANA", "Katakana"),
+        ("CYRILLIC", "Cyrillic"),
+        ("ARABIC", "Arabic"),
+        ("DEVANAGARI", "Devanagari"),
+        ("THAI", "Thai"),
+        ("GREEK", "Greek"),
+        ("HEBREW", "Hebrew"),
+        ("ARMENIAN", "Armenian"),
+        ("GEORGIAN", "Georgian"),
+        ("ETHIOPIC", "Ethiopic"),
+        ("LATIN", "Latin"),
+        ("IDEOGRAPH", "Han"),  # CJK Compatibility Ideographs
+    ]
+    for prefix, script in scripts:
+        if prefix in name_upper:
+            return script
+
+    # Fallback: if it's a letter, classify by block
+    if cat[0] == "L":
+        return "Unknown"
+    return None
+
+
+def check_script_purity(
+    text: str,
+    language: str,
+    threshold: float = 0.05,
+) -> dict:
+    """Check if text uses the expected Unicode script for a given language.
+
+    Args:
+        text: The text to validate.
+        language: ISO 639-1 language code (e.g. "ko", "de", "ar").
+        threshold: Max fraction of unexpected-script characters before
+            flagging as impure (default 5%).
+
+    Returns:
+        Dict with keys:
+        - script_pure (bool): True if unexpected chars are below threshold
+        - unexpected_ratio (float): Fraction of chars in unexpected scripts
+        - unexpected_chars (list): Sample of unexpected characters (max 10)
+        - expected_scripts (list): Scripts expected for this language
+    """
+    expected = _SCRIPT_RANGES.get(language)
+    if expected is None:
+        return {
+            "script_pure": True,
+            "unexpected_ratio": 0.0,
+            "unexpected_chars": [],
+            "expected_scripts": [],
+            "note": f"No script data for language '{language}', skipping validation",
+        }
+
+    total = 0
+    unexpected = 0
+    unexpected_samples: list[str] = []
+
+    for ch in text:
+        script = _char_script(ch)
+        if script is None:
+            continue  # skip punctuation, digits, whitespace
+        total += 1
+        if script not in expected:
+            unexpected += 1
+            if len(unexpected_samples) < 10:
+                unexpected_samples.append(ch)
+
+    ratio = unexpected / total if total > 0 else 0.0
+
+    return {
+        "script_pure": ratio <= threshold,
+        "unexpected_ratio": round(ratio, 4),
+        "unexpected_chars": unexpected_samples,
+        "expected_scripts": sorted(expected),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prompt-echo detection
+# ---------------------------------------------------------------------------
+
+# Common patterns where models echo back prompt instructions
+_ECHO_PATTERNS = [
+    re.compile(r"/\s*Language:\s*\w+", re.IGNORECASE),
+    re.compile(r"\[INST\].*?\[/INST\]", re.DOTALL),
+    re.compile(r"<<SYS>>.*?<</SYS>>", re.DOTALL),
+]
+
+
+def detect_prompt_echo(content: str, prompt: str | None = None) -> bool:
+    """Check if the model response contains echoed prompt instructions.
+
+    Args:
+        content: Model response text.
+        prompt: Original prompt (if provided, checks for substring overlap).
+
+    Returns:
+        True if prompt echo is detected.
+    """
+    for pattern in _ECHO_PATTERNS:
+        if pattern.search(content):
+            return True
+
+    if prompt and len(prompt) > 20:
+        # Check if a significant portion of the prompt appears in the response
+        # (more than 50 chars of exact match)
+        for i in range(0, len(prompt) - 50):
+            chunk = prompt[i:i + 50]
+            if chunk in content:
+                return True
+
+    return False

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,149 @@
+"""Tests for the text_utils module — think-tag stripping, script purity, prompt-echo detection."""
+
+import pytest
+
+from model_radar.text_utils import (
+    check_script_purity,
+    detect_prompt_echo,
+    strip_think_tags,
+)
+
+
+# ---------------------------------------------------------------------------
+# strip_think_tags
+# ---------------------------------------------------------------------------
+
+class TestStripThinkTags:
+    def test_no_think_tags(self):
+        content = "4,5,3"
+        cleaned, thinking = strip_think_tags(content)
+        assert cleaned == "4,5,3"
+        assert thinking is None
+
+    def test_complete_think_block(self):
+        content = "<think>\nOkay, let's analyze this...\n</think>\n4,5,3"
+        cleaned, thinking = strip_think_tags(content)
+        assert cleaned == "4,5,3"
+        assert "analyze" in thinking
+
+    def test_multiple_think_blocks(self):
+        content = "<think>first</think>hello<think>second</think>world"
+        cleaned, thinking = strip_think_tags(content)
+        assert cleaned == "helloworld"
+        assert thinking == "first"
+
+    def test_incomplete_think_block(self):
+        """Model hit max_tokens inside <think> — no closing tag."""
+        content = "<think>\nLet me think about this carefully..."
+        cleaned, thinking = strip_think_tags(content)
+        assert cleaned == ""
+        assert "carefully" in thinking
+
+    def test_empty_content(self):
+        cleaned, thinking = strip_think_tags("")
+        assert cleaned == ""
+        assert thinking is None
+
+    def test_none_like_empty(self):
+        # strip_think_tags should handle empty string gracefully
+        cleaned, thinking = strip_think_tags("")
+        assert cleaned == ""
+        assert thinking is None
+
+    def test_think_with_whitespace_after(self):
+        content = "<think>reasoning</think>  \n  answer"
+        cleaned, thinking = strip_think_tags(content)
+        assert cleaned == "answer"
+        assert thinking == "reasoning"
+
+    def test_real_qwen3_pattern(self):
+        """Simulate Qwen3 32B response to 'Output ONLY three numbers: 4,5,3'."""
+        content = (
+            "<think>\nOkay, let's tackle this. The user wants me to output "
+            "three numbers separated by commas. The numbers should be 4, 5, "
+            "and 3. Let me make sure I format this correctly.\n</think>\n4,5,3"
+        )
+        cleaned, thinking = strip_think_tags(content)
+        assert cleaned == "4,5,3"
+        assert thinking is not None
+        assert "tackle" in thinking
+
+
+# ---------------------------------------------------------------------------
+# check_script_purity
+# ---------------------------------------------------------------------------
+
+class TestCheckScriptPurity:
+    def test_pure_german(self):
+        result = check_script_purity("Vater, Haupt eines Haushalts", "de")
+        assert result["script_pure"] is True
+        assert result["unexpected_ratio"] == 0.0
+
+    def test_korean_with_hanja_leakage(self):
+        # Korean text with CJK characters mixed in (Hanja leakage)
+        text = "아버지, 가장" + "父" * 3  # 3 CJK chars mixed in
+        result = check_script_purity(text, "ko")
+        assert result["unexpected_ratio"] > 0
+        assert len(result["unexpected_chars"]) > 0
+
+    def test_pure_arabic(self):
+        result = check_script_purity("الأب، رب الأسرة", "ar")
+        assert result["script_pure"] is True
+
+    def test_chinese_allows_han(self):
+        result = check_script_purity("父亲，一家之主", "zh")
+        assert result["script_pure"] is True
+
+    def test_unknown_language(self):
+        result = check_script_purity("some text", "xx")
+        assert result["script_pure"] is True
+        assert "note" in result
+
+    def test_latin_with_cyrillic_leakage(self):
+        # Greek text that has Cyrillic characters (wrong script)
+        text = "πατέρας" + "Б" * 5
+        result = check_script_purity(text, "el")
+        assert result["unexpected_ratio"] > 0
+
+    def test_empty_text(self):
+        result = check_script_purity("", "en")
+        assert result["script_pure"] is True
+        assert result["unexpected_ratio"] == 0.0
+
+    def test_punctuation_only(self):
+        result = check_script_purity(".,!?;:", "en")
+        assert result["script_pure"] is True
+
+    def test_threshold_parameter(self):
+        # Mix of Korean + a small amount of CJK
+        text = "한국어 텍스트" + "字"
+        # With strict threshold should flag it
+        result_strict = check_script_purity(text, "ko", threshold=0.0)
+        # The CJK char is unexpected for Korean
+        assert result_strict["unexpected_ratio"] > 0
+
+
+# ---------------------------------------------------------------------------
+# detect_prompt_echo
+# ---------------------------------------------------------------------------
+
+class TestDetectPromptEcho:
+    def test_no_echo(self):
+        assert detect_prompt_echo("Vater, Haupt eines Haushalts") is False
+
+    def test_language_tag_echo(self):
+        content = "Vater, Haupt / Language: German"
+        assert detect_prompt_echo(content) is True
+
+    def test_inst_tag_echo(self):
+        content = "[INST] Translate to German [/INST] Vater"
+        assert detect_prompt_echo(content) is True
+
+    def test_prompt_substring_echo(self):
+        prompt = "Translate the following English definition to German: father, head of household"
+        content = "Translate the following English definition to German: father, head of household\n\nVater"
+        assert detect_prompt_echo(content, prompt) is True
+
+    def test_short_prompt_no_false_positive(self):
+        # Short prompts shouldn't trigger substring detection
+        assert detect_prompt_echo("hello world", "hi") is False


### PR DESCRIPTION
## Summary
Closes #5

Implements actionable improvements from real-world translation & evaluation pipeline lessons (428K Chinese dictionary entries + 19K biblical lexicon entries × 27 languages):

- **Think-tag stripping** (P1): New `text_utils.py` module strips `<think>...</think>` tags from model responses (fixes Qwen3 class of models that waste tokens on reasoning before structured output). Integrated into `_call_model()` and judge score parsing.
- **Script purity validation** (P2): `check_script_purity()` validates Unicode script ranges for 20+ languages — catches Hanja leakage in Korean, Cyrillic in Greek, CJK in Amharic, etc.
- **Prompt-echo detection** (P2): `detect_prompt_echo()` catches models that echo back instructions in their output.
- **Cost/token aggregation** (P3): `batch_run()` summary now includes aggregate `usage` (total_prompt_tokens, total_completion_tokens, total_tokens).
- **Provider-diverse fallback** (P2): `batch_run()` now prefers fallback models from different providers than the primary, preventing correlated failures when a provider goes down.
- **Docstring fix**: Removed duplicate Args block in `batch_judge_items`.

## Test plan
- [x] 22 new tests in `test_text_utils.py` (think-tag stripping, script purity, prompt-echo)
- [x] All 93 core tests pass (text_utils + runner + judge + scanner + providers + config)
- [ ] Manual verification with real Qwen3 model responses